### PR TITLE
Support building with VS2013

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ KillProc/ipch/*
 *.ncb
 *.sdf
 *.suo
+*.opensdf
 *.vcproj*
 *.vcxproj.user
 KillProc/Release/*
@@ -88,3 +89,4 @@ deps/
 sqlite3.exe
 messages.po
 translations/urbackup.frontend/en_new.po
+SolutionDependencies.props

--- a/SolutionDependencies.props.default
+++ b/SolutionDependencies.props.default
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros">
+    <WxWidgetsDir>C:\Tools\wxWidgets-3.0.2</WxWidgetsDir>
+    <WxWidgetsIncludeDir>$(WxWidgetsDir)\include</WxWidgetsIncludeDir>
+    <WxWidgetsLibDirX86Dbg>$(WxWidgetsDir)\lib\vc_lib</WxWidgetsLibDirX86Dbg>
+    <WxWidgetsLibDirX86Rel>$(WxWidgetsDir)\lib\vc_lib</WxWidgetsLibDirX86Rel>
+    <WxWidgetsLibDirX64Dbg>$(WxWidgetsDir)\lib\vc_x64_lib</WxWidgetsLibDirX64Dbg>
+    <WxWidgetsLibDirX64Rel>$(WxWidgetsDir)\lib\vc_x64_lib</WxWidgetsLibDirX64Rel>
+    <WxWidgetsVer>30</WxWidgetsVer>
+    <WxWidgetsDbgSuffix>d</WxWidgetsDbgSuffix>
+    <WxWidgetsRelSuffix />
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(Configuration)'=='Debug'">
+      <PropertyGroup Label="UserMacros">
+        <WxWidgetsCfgSuffix>$(WxWidgetsDbgSuffix)</WxWidgetsCfgSuffix>
+        <WxWidgetsLibDir Condition="'$(Platform)'=='Win32'">$(WxWidgetsLibDirX86Dbg)</WxWidgetsLibDir>
+        <WxWidgetsLibDir Condition="'$(Platform)'=='x64'">$(WxWidgetsLibDirX64Dbg)</WxWidgetsLibDir>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(Configuration)'=='Release'">
+      <PropertyGroup Label="UserMacros">
+        <WxWidgetsCfgSuffix>$(WxWidgetsRelSuffix)</WxWidgetsCfgSuffix>
+        <WxWidgetsLibDir Condition="'$(Platform)'=='Win32'">$(WxWidgetsLibDirX86Rel)</WxWidgetsLibDir>
+        <WxWidgetsLibDir Condition="'$(Platform)'=='x64'">$(WxWidgetsLibDirX64Rel)</WxWidgetsLibDir>
+      </PropertyGroup>
+    </When>
+  </Choose>
+  <PropertyGroup />
+  <ItemDefinitionGroup />
+  <ItemGroup>
+    <BuildMacro Include="WxWidgetsDir">
+      <Value>$(WxWidgetsDir)</Value>
+    </BuildMacro>
+    <BuildMacro Include="WxWidgetsIncludeDir">
+      <Value>$(WxWidgetsIncludeDir)</Value>
+    </BuildMacro>
+    <BuildMacro Include="WxWidgetsLibDirX86Dbg">
+      <Value>$(WxWidgetsLibDirX86Dbg)</Value>
+    </BuildMacro>
+    <BuildMacro Include="WxWidgetsLibDirX86Rel">
+      <Value>$(WxWidgetsLibDirX86Rel)</Value>
+    </BuildMacro>
+    <BuildMacro Include="WxWidgetsLibDirX64Dbg">
+      <Value>$(WxWidgetsLibDirX64Dbg)</Value>
+    </BuildMacro>
+    <BuildMacro Include="WxWidgetsLibDirX64Rel">
+      <Value>$(WxWidgetsLibDirX64Rel)</Value>
+    </BuildMacro>
+    <BuildMacro Include="WxWidgetsVer">
+      <Value>$(WxWidgetsVer)</Value>
+    </BuildMacro>
+    <BuildMacro Include="WxWidgetsDbgSuffix">
+      <Value>$(WxWidgetsDbgSuffix)</Value>
+    </BuildMacro>
+    <BuildMacro Include="WxWidgetsRelSuffix">
+      <Value>$(WxWidgetsRelSuffix)</Value>
+    </BuildMacro>
+  </ItemGroup>
+</Project>

--- a/TaskBarBaloon.cpp
+++ b/TaskBarBaloon.cpp
@@ -144,8 +144,7 @@ HANDLE ExecuteProcess( const std::string & exe, const std::string &args, const s
 void update_urbackup(void)
 {
 #ifdef _WIN32
-	wxStandardPaths sp;
-	std::string e_pstr=ExtractFilePath(sp.GetExecutablePath().ToUTF8().data());
+	std::string e_pstr=ExtractFilePath(wxStandardPaths::Get().GetExecutablePath().ToUTF8().data());
 	ExecuteProcess(e_pstr+"\\UrBackupUpdate.exe","","");
 	timer->resetDisplayedUpdateInfo();
 #endif

--- a/UrBackupClientGUI_VS12.sln
+++ b/UrBackupClientGUI_VS12.sln
@@ -1,0 +1,26 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "UrBackupClientGUI", "UrBackupClientGUI_VS12.vcxproj", "{260478D4-66ED-4F93-829A-8F9EDF0063A5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
+		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{260478D4-66ED-4F93-829A-8F9EDF0063A5}.Debug|Win32.ActiveCfg = Debug|x64
+		{260478D4-66ED-4F93-829A-8F9EDF0063A5}.Debug|Win32.Build.0 = Debug|x64
+		{260478D4-66ED-4F93-829A-8F9EDF0063A5}.Debug|x64.ActiveCfg = Debug|x64
+		{260478D4-66ED-4F93-829A-8F9EDF0063A5}.Debug|x64.Build.0 = Debug|x64
+		{260478D4-66ED-4F93-829A-8F9EDF0063A5}.Release|Win32.ActiveCfg = Release|Win32
+		{260478D4-66ED-4F93-829A-8F9EDF0063A5}.Release|Win32.Build.0 = Release|Win32
+		{260478D4-66ED-4F93-829A-8F9EDF0063A5}.Release|x64.ActiveCfg = Release|x64
+		{260478D4-66ED-4F93-829A-8F9EDF0063A5}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/UrBackupClientGUI_VS12.sln
+++ b/UrBackupClientGUI_VS12.sln
@@ -1,6 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "UrBackupClientGUI", "UrBackupClientGUI_VS12.vcxproj", "{260478D4-66ED-4F93-829A-8F9EDF0063A5}"
 EndProject
 Global
@@ -11,8 +13,8 @@ Global
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{260478D4-66ED-4F93-829A-8F9EDF0063A5}.Debug|Win32.ActiveCfg = Debug|x64
-		{260478D4-66ED-4F93-829A-8F9EDF0063A5}.Debug|Win32.Build.0 = Debug|x64
+		{260478D4-66ED-4F93-829A-8F9EDF0063A5}.Debug|Win32.ActiveCfg = Debug|Win32
+		{260478D4-66ED-4F93-829A-8F9EDF0063A5}.Debug|Win32.Build.0 = Debug|Win32
 		{260478D4-66ED-4F93-829A-8F9EDF0063A5}.Debug|x64.ActiveCfg = Debug|x64
 		{260478D4-66ED-4F93-829A-8F9EDF0063A5}.Debug|x64.Build.0 = Debug|x64
 		{260478D4-66ED-4F93-829A-8F9EDF0063A5}.Release|Win32.ActiveCfg = Release|Win32

--- a/UrBackupClientGUI_VS12.vcxproj
+++ b/UrBackupClientGUI_VS12.vcxproj
@@ -1,0 +1,230 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{260478D4-66ED-4F93-829A-8F9EDF0063A5}</ProjectGuid>
+    <RootNamespace>UrBackupClientGUI</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(Configuration)\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(Configuration)\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(Platform)\$(Configuration)\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</LinkIncremental>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(Platform)\$(Configuration)\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkIncremental>
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>D:\Developement\libs\wxWidgets\wxWidgets\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_ITERATOR_DEBUG_LEVEL=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>wxbase29u_net.lib;wxzlib.lib;wxregexu.lib;wxpng.lib;wxbase29u.lib;wxmswuniv29u_core.lib;wxmswuniv29u_adv.lib;wxexpat.lib;comctl32.lib;Rpcrt4.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>wx64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>deps\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;DD_RELEASE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>wxbase29u.lib;wxmsw29u_core.lib;wxmsw29u_adv.lib;wxexpat.lib;comctl32.lib;Rpcrt4.lib;wxbase29u_net.lib;ws2_32.lib;wxpng.lib;wxzlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>deps\win\wx86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>D:\Developement\libs\wxWidgets\wxWidgets\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>wxpngd.lib;wxbase29ud.lib;wxexpatd.lib;comctl32.lib;Rpcrt4.lib;wxbase29ud_net.lib;ws2_32.lib;wxzlibd.lib;wxmsw29ud_core.lib;wxmsw29ud_adv.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>D:\Developement\libs\wxWidgets\wxWidgets\lib\vc_lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>deps\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;DD_RELEASE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>wxbase29u.lib;wxmsw29u_core.lib;wxmsw29u_adv.lib;wxexpat.lib;comctl32.lib;Rpcrt4.lib;wxbase29u_net.lib;ws2_32.lib;wxpng.lib;wxzlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>deps\win\wx64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="ConfigPath.cpp" />
+    <ClCompile Include="Connector.cpp" />
+    <ClCompile Include="escape.cpp" />
+    <ClCompile Include="FileSettingsReader.cpp" />
+    <ClCompile Include="Info.cpp" />
+    <ClCompile Include="jsoncpp.cpp" />
+    <ClCompile Include="Logs.cpp" />
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="Settings.cpp" />
+    <ClCompile Include="Status.cpp" />
+    <ClCompile Include="stringtools.cpp" />
+    <ClCompile Include="TaskBarBaloon.cpp" />
+    <ClCompile Include="tcpstack.cpp" />
+    <ClCompile Include="TranslationHelper.cpp" />
+    <ClCompile Include="TrayIcon.cpp" />
+    <ClCompile Include="gui\GUI.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="capa_bits.h" />
+    <ClInclude Include="ConfigPath.h" />
+    <ClInclude Include="Connector.h" />
+    <ClInclude Include="escape.h" />
+    <ClInclude Include="FileSettingsReader.h" />
+    <ClInclude Include="Info.h" />
+    <ClInclude Include="Logs.h" />
+    <ClInclude Include="main.h" />
+    <ClInclude Include="resource.h" />
+    <ClInclude Include="Settings.h" />
+    <ClInclude Include="Status.h" />
+    <ClInclude Include="stringtools.h" />
+    <ClInclude Include="TaskBarBaloon.h" />
+    <ClInclude Include="tcpstack.h" />
+    <ClInclude Include="TranslationHelper.h" />
+    <ClInclude Include="TrayIcon.h" />
+    <ClInclude Include="gui\GUI.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="icon1.ico" />
+    <None Include="icon2.ico" />
+    <None Include="icon3.ico" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="UrBackupClientGUI.rc" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/UrBackupClientGUI_VS12.vcxproj
+++ b/UrBackupClientGUI_VS12.vcxproj
@@ -52,15 +52,19 @@
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="SolutionDependencies.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="SolutionDependencies.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="SolutionDependencies.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="SolutionDependencies.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
@@ -93,8 +97,8 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>D:\Developement\libs\wxWidgets\wxWidgets\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_ITERATOR_DEBUG_LEVEL=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(WxWidgetsIncludeDir);$(WxWidgetsLibDir)\mswu$(WxWidgetsCfgSuffix);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -104,8 +108,8 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>wxbase29u_net.lib;wxzlib.lib;wxregexu.lib;wxpng.lib;wxbase29u.lib;wxmswuniv29u_core.lib;wxmswuniv29u_adv.lib;wxexpat.lib;comctl32.lib;Rpcrt4.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>wx64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>wxbase$(WxWidgetsVer)u$(WxWidgetsCfgSuffix).lib;wxbase$(WxWidgetsVer)u$(WxWidgetsCfgSuffix)_net.lib;wxmsw$(WxWidgetsVer)u$(WxWidgetsCfgSuffix)_adv.lib;wxmsw$(WxWidgetsVer)u$(WxWidgetsCfgSuffix)_core.lib;wxpng$(WxWidgetsCfgSuffix).lib;wxzlib$(WxWidgetsCfgSuffix).lib;comctl32.lib;rpcrt4.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(WxWidgetsLibDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
@@ -115,7 +119,7 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>deps\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WxWidgetsIncludeDir);$(WxWidgetsLibDir)\mswu$(WxWidgetsCfgSuffix);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;DD_RELEASE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -125,8 +129,8 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>wxbase29u.lib;wxmsw29u_core.lib;wxmsw29u_adv.lib;wxexpat.lib;comctl32.lib;Rpcrt4.lib;wxbase29u_net.lib;ws2_32.lib;wxpng.lib;wxzlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>deps\win\wx86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>wxbase$(WxWidgetsVer)u$(WxWidgetsCfgSuffix).lib;wxbase$(WxWidgetsVer)u$(WxWidgetsCfgSuffix)_net.lib;wxmsw$(WxWidgetsVer)u$(WxWidgetsCfgSuffix)_adv.lib;wxmsw$(WxWidgetsVer)u$(WxWidgetsCfgSuffix)_core.lib;wxpng$(WxWidgetsCfgSuffix).lib;wxzlib$(WxWidgetsCfgSuffix).lib;comctl32.lib;rpcrt4.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(WxWidgetsLibDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -140,7 +144,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>D:\Developement\libs\wxWidgets\wxWidgets\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WxWidgetsIncludeDir);$(WxWidgetsLibDir)\mswu$(WxWidgetsCfgSuffix);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -151,8 +155,8 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>wxpngd.lib;wxbase29ud.lib;wxexpatd.lib;comctl32.lib;Rpcrt4.lib;wxbase29ud_net.lib;ws2_32.lib;wxzlibd.lib;wxmsw29ud_core.lib;wxmsw29ud_adv.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>D:\Developement\libs\wxWidgets\wxWidgets\lib\vc_lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>wxbase$(WxWidgetsVer)u$(WxWidgetsCfgSuffix).lib;wxbase$(WxWidgetsVer)u$(WxWidgetsCfgSuffix)_net.lib;wxmsw$(WxWidgetsVer)u$(WxWidgetsCfgSuffix)_adv.lib;wxmsw$(WxWidgetsVer)u$(WxWidgetsCfgSuffix)_core.lib;wxpng$(WxWidgetsCfgSuffix).lib;wxzlib$(WxWidgetsCfgSuffix).lib;comctl32.lib;rpcrt4.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(WxWidgetsLibDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX64</TargetMachine>
@@ -165,7 +169,7 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>deps\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WxWidgetsIncludeDir);$(WxWidgetsLibDir)\mswu$(WxWidgetsCfgSuffix);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;DD_RELEASE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -175,8 +179,8 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>wxbase29u.lib;wxmsw29u_core.lib;wxmsw29u_adv.lib;wxexpat.lib;comctl32.lib;Rpcrt4.lib;wxbase29u_net.lib;ws2_32.lib;wxpng.lib;wxzlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>deps\win\wx64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>wxbase$(WxWidgetsVer)u$(WxWidgetsCfgSuffix).lib;wxbase$(WxWidgetsVer)u$(WxWidgetsCfgSuffix)_net.lib;wxmsw$(WxWidgetsVer)u$(WxWidgetsCfgSuffix)_adv.lib;wxmsw$(WxWidgetsVer)u$(WxWidgetsCfgSuffix)_core.lib;wxpng$(WxWidgetsCfgSuffix).lib;wxzlib$(WxWidgetsCfgSuffix).lib;comctl32.lib;rpcrt4.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(WxWidgetsLibDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>

--- a/UrBackupClientGUI_VS12.vcxproj
+++ b/UrBackupClientGUI_VS12.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -22,25 +22,30 @@
     <ProjectGuid>{260478D4-66ED-4F93-829A-8F9EDF0063A5}</ProjectGuid>
     <RootNamespace>UrBackupClientGUI</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <ProjectName>UrBackupClientGUI</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/UrBackupClientGUI_VS12.vcxproj.filters
+++ b/UrBackupClientGUI_VS12.vcxproj.filters
@@ -1,0 +1,142 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Quelldateien">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Headerdateien">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Ressourcendateien">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav</Extensions>
+    </Filter>
+    <Filter Include="GUI">
+      <UniqueIdentifier>{59437933-cec2-425e-b03b-fa40069e48bb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="jsoncpp">
+      <UniqueIdentifier>{a12c0f84-292a-4778-8b4a-128e18592502}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="ConfigPath.cpp">
+      <Filter>Quelldateien</Filter>
+    </ClCompile>
+    <ClCompile Include="Connector.cpp">
+      <Filter>Quelldateien</Filter>
+    </ClCompile>
+    <ClCompile Include="escape.cpp">
+      <Filter>Quelldateien</Filter>
+    </ClCompile>
+    <ClCompile Include="FileSettingsReader.cpp">
+      <Filter>Quelldateien</Filter>
+    </ClCompile>
+    <ClCompile Include="Info.cpp">
+      <Filter>Quelldateien</Filter>
+    </ClCompile>
+    <ClCompile Include="Logs.cpp">
+      <Filter>Quelldateien</Filter>
+    </ClCompile>
+    <ClCompile Include="main.cpp">
+      <Filter>Quelldateien</Filter>
+    </ClCompile>
+    <ClCompile Include="Settings.cpp">
+      <Filter>Quelldateien</Filter>
+    </ClCompile>
+    <ClCompile Include="stringtools.cpp">
+      <Filter>Quelldateien</Filter>
+    </ClCompile>
+    <ClCompile Include="tcpstack.cpp">
+      <Filter>Quelldateien</Filter>
+    </ClCompile>
+    <ClCompile Include="TrayIcon.cpp">
+      <Filter>Quelldateien</Filter>
+    </ClCompile>
+    <ClCompile Include="gui\GUI.cpp">
+      <Filter>GUI</Filter>
+    </ClCompile>
+    <ClCompile Include="TaskBarBaloon.cpp">
+      <Filter>Quelldateien</Filter>
+    </ClCompile>
+    <ClCompile Include="jsoncpp.cpp">
+      <Filter>jsoncpp</Filter>
+    </ClCompile>
+    <ClCompile Include="Status.cpp">
+      <Filter>Quelldateien</Filter>
+    </ClCompile>
+    <ClCompile Include="TranslationHelper.cpp">
+      <Filter>Quelldateien</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="ConfigPath.h">
+      <Filter>Headerdateien</Filter>
+    </ClInclude>
+    <ClInclude Include="Connector.h">
+      <Filter>Headerdateien</Filter>
+    </ClInclude>
+    <ClInclude Include="escape.h">
+      <Filter>Headerdateien</Filter>
+    </ClInclude>
+    <ClInclude Include="FileSettingsReader.h">
+      <Filter>Headerdateien</Filter>
+    </ClInclude>
+    <ClInclude Include="Info.h">
+      <Filter>Headerdateien</Filter>
+    </ClInclude>
+    <ClInclude Include="Logs.h">
+      <Filter>Headerdateien</Filter>
+    </ClInclude>
+    <ClInclude Include="main.h">
+      <Filter>Headerdateien</Filter>
+    </ClInclude>
+    <ClInclude Include="resource.h">
+      <Filter>Headerdateien</Filter>
+    </ClInclude>
+    <ClInclude Include="Settings.h">
+      <Filter>Headerdateien</Filter>
+    </ClInclude>
+    <ClInclude Include="stringtools.h">
+      <Filter>Headerdateien</Filter>
+    </ClInclude>
+    <ClInclude Include="tcpstack.h">
+      <Filter>Headerdateien</Filter>
+    </ClInclude>
+    <ClInclude Include="TrayIcon.h">
+      <Filter>Headerdateien</Filter>
+    </ClInclude>
+    <ClInclude Include="gui\GUI.h">
+      <Filter>GUI</Filter>
+    </ClInclude>
+    <ClInclude Include="TaskBarBaloon.h">
+      <Filter>Headerdateien</Filter>
+    </ClInclude>
+    <ClInclude Include="capa_bits.h">
+      <Filter>Headerdateien</Filter>
+    </ClInclude>
+    <ClInclude Include="Status.h">
+      <Filter>Headerdateien</Filter>
+    </ClInclude>
+    <ClInclude Include="TranslationHelper.h">
+      <Filter>Headerdateien</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="icon1.ico">
+      <Filter>Ressourcendateien</Filter>
+    </None>
+    <None Include="icon2.ico">
+      <Filter>Ressourcendateien</Filter>
+    </None>
+    <None Include="icon3.ico">
+      <Filter>Ressourcendateien</Filter>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="UrBackupClientGUI.rc">
+      <Filter>Ressourcendateien</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+</Project>

--- a/stringtools.cpp
+++ b/stringtools.cpp
@@ -1049,11 +1049,6 @@ void ParseParamStr(const std::string &pStr, std::map<std::wstring,std::wstring> 
 	}
 }
 
-int round(float f)
-{
-  return (int)(f<0?f-0.5f:f+0.5f);
-}
-
 std::string FormatTime(int timeins)
 {
 	float t=(float)timeins;

--- a/stringtools.h
+++ b/stringtools.h
@@ -87,7 +87,6 @@ void EscapeCh(std::wstring &pStr, wchar_t ch);
 std::string UnescapeSQLString(std::string pStr);
 std::wstring UnescapeSQLString(std::wstring pStr);
 void ParseParamStr(const std::string &pStr, std::map<std::wstring,std::wstring> *pMap);
-int round(float f);
 std::string FormatTime(int timeins);
 bool IsHex(const std::string &str);
 unsigned long hexToULong(const std::string &data);


### PR DESCRIPTION
As with the similar pull request in the urbackup_frontend repo, this creates a new solution (UrBackupClientGUI_VS12.sln) and associated project files so VS2013 (VS12) can be used.  The original solution/projects are unchanged, so VS2010 support should be unaffected.

I've verified this works with the current wxWidgets 3.0.2 and with 2.9.5.  That's the version in your deps repo, though I had to pull down the 2.9.5 sources from wxWidgets, which have many differences from your version.    I can't build with your deps, since those libs were compiled by VS2010 and are incompatible with a VS2013 build of the project.

There's a new property page required, SolutionDependencies.props.  Copy the committed SolutionDependencies.props.default over to create the property sheet, then modify it as needed to point to the location of wxWidgets include files and libs.

There were a couple minor buildfixes required, including stringtools.{cpp,h} to build with VS2013's CRT, and another in TaskBarBaloon.cpp to build with wxWidgets 3.0. 
