### PR TITLE
macOS remove redundant launch item

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -142,7 +142,6 @@ HRESULT ModifyPrivilege(
 
 #ifdef __APPLE__
 extern "C" void bring_to_foreground();
-extern "C" void register_login_item();
 extern "C" void remove_login_item();
 #endif
 
@@ -600,11 +599,6 @@ bool MyApp::OnInit()
 		std::string uninstaller = SBINDIR "/urbackup_uninstall";
 		wxExecute("/bin/sh \"" + uninstaller + "\"", wxEXEC_SYNC, NULL, NULL);
 		wxExit();
-	}
-	else if(cmd==wxT("register_login_item"))
-	{
-		register_login_item();
-		exit(0);
 	}
 	else if(cmd==wxT("remove_login_item"))
 	{

--- a/osxutils.mm
+++ b/osxutils.mm
@@ -7,53 +7,6 @@ extern "C" void bring_to_foreground()
 	[NSApp activateIgnoringOtherApps:YES];
 }
 
-extern "C" void register_login_item()
-{
-	AuthorizationItem right[1] = {{"system.global-login-items.", 0, NULL, 0}};
-	AuthorizationRights rights = {1, right};
-	AuthorizationRef auth = NULL; 
-	AuthorizationCreate(NULL, kAuthorizationEmptyEnvironment, kAuthorizationFlagDefaults, &auth);
-	
-	if(auth==NULL)
-	{
-		return;
-	}
-
-	AuthorizationCopyRights(auth, &rights, kAuthorizationEmptyEnvironment,
-                              (kAuthorizationFlagDefaults
-                               | kAuthorizationFlagInteractionAllowed
-                               | kAuthorizationFlagExtendRights), NULL);
-
-	LSSharedFileListRef login_items = LSSharedFileListCreate(NULL, kLSSharedFileListGlobalLoginItems, NULL);
-	if(login_items==NULL)
-	{
-		return;
-	}
-
-	NSString* app_path = [[[NSBundle mainBundle] bundleURL] absoluteString];
-
-	LSSharedFileListSetAuthorization(login_items, auth);
-
-	UInt32 seed;
-	CFArrayRef login_items_array = LSSharedFileListCopySnapshot(login_items, &seed);
-	for (id item in (NSArray *)login_items_array)
-	{       
-	    LSSharedFileListItemRef item_ref = (LSSharedFileListItemRef)item;
-	    CFURLRef item_path;
-	    if (LSSharedFileListItemResolve(item_ref, 0, (CFURLRef*) &item_path, NULL) == noErr)
-	    {
-	        if ([[(NSURL *)item_path path] hasPrefix:app_path])
-	        {
-	            return;
-	        }
-	    }       
-	}
-
-	NSURL* app_url = [[NSBundle mainBundle] bundleURL];
-	LSSharedFileListInsertItemURL(login_items, kLSSharedFileListItemLast,
-                                  NULL, NULL, (CFURLRef)(app_url), NULL, NULL);
-}
-
 extern "C" void remove_login_item()
 {
 	AuthorizationItem right[1] = {{"system.global-login-items.", 0, NULL, 0}};


### PR DESCRIPTION
To be used in concert with the corresponding backend PR.

Removes the now-deprecated user login item, as we're using launchctl to launch the backend and client processes.