### PR TITLE
macOS - Check for Full Disk Access

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -142,7 +142,6 @@ HRESULT ModifyPrivilege(
 
 #ifdef __APPLE__
 extern "C" void bring_to_foreground();
-extern "C" void register_login_item();
 extern "C" void remove_login_item();
 #endif
 
@@ -600,11 +599,6 @@ bool MyApp::OnInit()
 		std::string uninstaller = SBINDIR "/urbackup_uninstall";
 		wxExecute("/bin/sh \"" + uninstaller + "\"", wxEXEC_SYNC, NULL, NULL);
 		wxExit();
-	}
-	else if(cmd==wxT("register_login_item"))
-	{
-		register_login_item();
-		exit(0);
 	}
 	else if(cmd==wxT("remove_login_item"))
 	{

--- a/main.cpp
+++ b/main.cpp
@@ -143,6 +143,7 @@ HRESULT ModifyPrivilege(
 #ifdef __APPLE__
 extern "C" void bring_to_foreground();
 extern "C" void remove_login_item();
+extern "C" void check_full_disk_access();
 #endif
 
 class TheFrame : public wxFrame {
@@ -512,6 +513,10 @@ bool MyApp::OnInit()
 		timer=new MyTimer;
 
 		timer->Start(1000);
+        
+        #ifdef __APPLE__
+        check_full_disk_access();
+        #endif
 	}
 	else if(cmd==wxT("settings"))
 	{

--- a/osxutils.mm
+++ b/osxutils.mm
@@ -49,3 +49,86 @@ extern "C" void remove_login_item()
 	    }       
 	}
 }
+
+// check_full_disk_access() based on MacPaw's PermissionsKit
+// https://github.com/MacPaw/PermissionsKit
+// PermissionsKit Copyright (c) 2018 MacPaw
+// MIT License
+//
+
+extern "C" void check_full_disk_access()
+{
+    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+    
+    if (@available(macOS 10.14, *))
+    {
+//        Full Disk Access only required for macOS 10.14+
+        NSLog(@"[macOS] macOS 10.14 or higher installed - need to check for Full Disk Access");
+    } else {
+        NSLog(@"[macOS] macOS 10.13 or lower installed - no need to check for Full Disk Access");
+        return;
+    }
+    
+//    Check for file access
+    NSFileManager *filemanager = [NSFileManager defaultManager];
+    NSString *path;
+    BOOL fileExists;
+
+    path = [NSHomeDirectory()  stringByAppendingPathComponent:@"Library/Safari/CloudTabs.db"];
+    fileExists = [filemanager fileExistsAtPath:path];
+    if (fileExists)
+    {
+        NSLog(@"[macOS] ~/Library/Safari/CloudTabs.db exists - use for Full Disk Access check");
+    }
+    else
+    {
+        path = [NSHomeDirectory()  stringByAppendingPathComponent:@"Library/Safari/Bookmarks.plist"];
+        fileExists = [filemanager fileExistsAtPath:path];
+        if (fileExists)
+        {
+            NSLog(@"[macOS] ~/Library/Safari/Bookmarks.plist exists - use for Full Disk Access check");
+        }
+        else
+        {
+            path = [NSHomeDirectory()  stringByAppendingPathComponent:@"Library/Accounts/Accounts4.sqlite"];
+            fileExists = [filemanager fileExistsAtPath:path];
+            if (fileExists)
+            {
+                NSLog(@"[macOS] ~/Library/Accounts/Accounts4.sqlite exists - use for Full Disk Access check");
+            }
+        }
+    }
+    
+    NSData* data = [NSData dataWithContentsOfFile:path];
+    NSAlert *alert = [[NSAlert alloc] init];
+    [alert setAlertStyle:NSAlertStyleCritical];
+    if (data != nil && fileExists)
+    {
+//        Full Disk Access Allowed
+        NSLog(@"[macOS] Full Disk Access Allowed");
+    }
+    else
+    {
+        if (data == nil && fileExists)
+        {
+//        Full Disk Access Denied
+            NSLog(@"[macOS] Full Disk Access Denied");
+            [alert setMessageText:@"Full Disk Access Denied"];
+            [alert setInformativeText:@"UrBackup needs Full Disk Access to operate.\n\nPlease use System Preferences to allow the UrBackup Client application Full Disk Access.\n\nSystem Preferences will open when you press OK."];
+        }
+        else
+        {
+//        Cannot determine Full Disk Access status
+            NSLog(@"[macOS] Full Disk Access cannot be determined");
+            [alert setMessageText:@"Cannot determine Full Disk Access status"];
+            [alert setInformativeText:@"UrBackup needs Full Disk Access to operate.\n\nPlease try using System Preferences to allow the UrBackup Client application Full Disk Access.\n\nSystem Preferences will open when you press OK."];
+        }
+//        Display dialogue
+        [alert runModal];
+//        Open System Preferences
+        NSWorkspace *workspace = [[NSWorkspace alloc] init];
+        [workspace openURL:[NSURL URLWithString:@"x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles"]];
+    }
+    [pool drain];
+    return;
+}

--- a/osxutils.mm
+++ b/osxutils.mm
@@ -7,53 +7,6 @@ extern "C" void bring_to_foreground()
 	[NSApp activateIgnoringOtherApps:YES];
 }
 
-extern "C" void register_login_item()
-{
-	AuthorizationItem right[1] = {{"system.global-login-items.", 0, NULL, 0}};
-	AuthorizationRights rights = {1, right};
-	AuthorizationRef auth = NULL; 
-	AuthorizationCreate(NULL, kAuthorizationEmptyEnvironment, kAuthorizationFlagDefaults, &auth);
-	
-	if(auth==NULL)
-	{
-		return;
-	}
-
-	AuthorizationCopyRights(auth, &rights, kAuthorizationEmptyEnvironment,
-                              (kAuthorizationFlagDefaults
-                               | kAuthorizationFlagInteractionAllowed
-                               | kAuthorizationFlagExtendRights), NULL);
-
-	LSSharedFileListRef login_items = LSSharedFileListCreate(NULL, kLSSharedFileListGlobalLoginItems, NULL);
-	if(login_items==NULL)
-	{
-		return;
-	}
-
-	NSString* app_path = [[[NSBundle mainBundle] bundleURL] absoluteString];
-
-	LSSharedFileListSetAuthorization(login_items, auth);
-
-	UInt32 seed;
-	CFArrayRef login_items_array = LSSharedFileListCopySnapshot(login_items, &seed);
-	for (id item in (NSArray *)login_items_array)
-	{       
-	    LSSharedFileListItemRef item_ref = (LSSharedFileListItemRef)item;
-	    CFURLRef item_path;
-	    if (LSSharedFileListItemResolve(item_ref, 0, (CFURLRef*) &item_path, NULL) == noErr)
-	    {
-	        if ([[(NSURL *)item_path path] hasPrefix:app_path])
-	        {
-	            return;
-	        }
-	    }       
-	}
-
-	NSURL* app_url = [[NSBundle mainBundle] bundleURL];
-	LSSharedFileListInsertItemURL(login_items, kLSSharedFileListItemLast,
-                                  NULL, NULL, (CFURLRef)(app_url), NULL, NULL);
-}
-
 extern "C" void remove_login_item()
 {
 	AuthorizationItem right[1] = {{"system.global-login-items.", 0, NULL, 0}};


### PR DESCRIPTION
macOS 10.14+ requires Full Disk Access permission to arbitrarily read files across the filesystem.

This PR checks for read access to a few choice files, and then presents the necessary interface to allow the user to easily enable Full Disk Access if required.